### PR TITLE
Add local rendering instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,15 @@
+.DEFAULT_GOAL:=preview
+
+preview:
+	docker run --rm -it \
+		-v "${PWD}":/src \
+		-p 1313:1313 \
+		klakegg/hugo:0.101.0-ext-alpine \
+		server -w --bind=0.0.0.0
+
 mdlint:
 	docker run --rm \
 		-v "$$(pwd)":/workdir \
 		ghcr.io/igorshubovych/markdownlint-cli:latest \
 		"**/*.md"
+

--- a/README.md
+++ b/README.md
@@ -6,6 +6,39 @@ This repository is the source to the Bottlerocket project website. It contains t
 
 The Bottlerocket website is open to contribution and collaboration. See [CONTRIBUTING](CONTRIBUTING.md) for specific instructions.
 
+### Rendering Locally
+
+This site uses [Hugo](https://github.com/gohugoio/hugo) for rendering.
+You may run `hugo` locally to validate your changes render properly.
+
+#### Rendering
+
+If [`hugo` is installed](#hugo-installation), you may view the rendered site by running:
+
+```sh
+# To render everything, including draft posts
+hugo server -D
+
+# To render the site as it will appear when being published
+hugo server
+```
+
+If you use `make`, have `docker`, and do not have `hugo` installed, you may also use the following `make` target as a convenience:
+
+```sh
+make preview
+```
+
+#### Hugo Installation
+
+Hugo is available for many platforms.
+
+- Linux: most native package managers
+- macOS: `brew install hugo`
+- Windows: `choco install hugo`
+
+See the [Hugo installation instructions](https://gohugo.io/getting-started/installing/) for additional options.
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.


### PR DESCRIPTION
*Description of changes:*

This adds some details on how to render the site locally. It also adds a
Makefile target that will use a containerized `hugo` to make it easier
for general developers to be able to view changes locally.


By submitting this pull request, I confirm that my contribution is made under the terms of the licenses outlined in the LICENSE-SUMMARY file.