### PR TITLE
adds descriptions to category and content pages

### DIFF
--- a/content/en/os/1.13.x/concepts/_index.markdown
+++ b/content/en/os/1.13.x/concepts/_index.markdown
@@ -1,4 +1,5 @@
 +++
 title="Concepts"
 type="docs"
+description="High-level concepts in Bottlerocket"
 +++

--- a/content/en/os/1.13.x/concepts/updating-bottlerocket/index.markdown
+++ b/content/en/os/1.13.x/concepts/updating-bottlerocket/index.markdown
@@ -1,6 +1,7 @@
 +++
 title = "Updating Bottlerocket"
 type = "docs"
+description = "Overview of different methods to update Bottlerocket" 
 +++
 
 There are many ways to update Bottlerocket, including:

--- a/content/en/os/1.13.x/update/_index.markdown
+++ b/content/en/os/1.13.x/update/_index.markdown
@@ -1,4 +1,5 @@
 +++
 title="Updating"
 type="docs"
+description="Details on moving to newer versions of Bottlerocket"
 +++

--- a/content/en/os/1.13.x/update/guidelines/index.markdown
+++ b/content/en/os/1.13.x/update/guidelines/index.markdown
@@ -1,6 +1,7 @@
 +++
 title="Guidelines for Updating In-Place"
 type="docs"
+description="Moving to newer versions without replacing nodes"
 +++
 
 ## Introduction


### PR DESCRIPTION
**Issue number:**

Closes # n/a

**Description of changes:**

Adds `description` front matter to the existing content directories (`_index.markdown`) and content markdown.  


**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
