### PR TITLE
switch DIRECTORY-STRUCTURE.md to directories

### DIFF
--- a/DIRECTORY-STRUCTURE.md
+++ b/DIRECTORY-STRUCTURE.md
@@ -9,6 +9,12 @@ The documentation is localizeable and is placed in directory per language to fac
 Bottlerocket's documentation is placed in the `os` directory with subdirectories for each version - allowing for alignment between releases and documentation.
 Every directory or page in the versioned tree is intended to have clear meaning without much pre-existing Bottlerocket context (e.g. `introduction`, `install`, `update`, etc.).
 
+A caveat of Docsy (used in this site for supporting multiple languages) is that in order to render titles properly in the sidebar, content pages must be placed in their own subdirectory, with the content itself residing in `index.markdown`.
+See more details in [issue 39](https://github.com/bottlerocket-os/project-website/issues/39).
+This applies to pages in the localized content directory such as `content/en/`.
+For example, what normally would be `content/en/faq.markdown` would be `content/en/faq/index.markdown`.
+Content in subdirectories that are headless such as `content/en/faqitems/` are not rendered as individual pages and thus do not need to be placed in their own per-page subdirectories.
+
 Other user-facing repos (`control-container`, `brupop`, etc.) and components are in their own versioned trees with links provided to relevant versions of the OS as required.
 This decouples versioning from the OS and allows for documentation of out-of-phase releases.
 
@@ -27,43 +33,43 @@ This may not be comprehensive for every file, but should be considered a living 
 │   │   ├── general-01-what-is-bottlerocket.markdown
 │   │   ├── release-02-why-was-bottlerocket-created.markdown
 │   │   └── [... more FAQs]
-│   ├── faq.markdown [Single page rendering for faqitems bundle]
+│   ├── faq [Single page rendering for faqitems bundle]
 │   ├── os [Bottlerocket's documentation]
 │   │   ├── 1.12.x [versioned content, each new minor version gets a new directrory]
-│   │   │   ├── introduction.markdown
+│   │   │   ├── introduction
 │   │   │   ├── install [how to put Bottlerocket on a node]
 │   │   │   │   ├── manual [install instructions without high level tools]
 │   │   │   │   │   ├── aws [each platform gets an directory]
-│   │   │   │   │   │   ├── k8s.markdown [each orchestrator gets a page]
+│   │   │   │   │   │   ├── k8s [each orchestrator gets a page]
 │   │   │   │   │   │   └── [... more orchestrators]
 │   │   │   │   │   └── [... more platforms]
 │   │   │   │   └── quickstart [install instructions with high level tools]
 │   │   │   │       ├── aws [each platform gets an directory]
-│   │   │   │       │   ├── k8s.markdown [each orchestrator gets a page, tools are headings on page]
+│   │   │   │       │   ├── k8s [each orchestrator gets a page, tools are headings on page]
 │   │   │   │       │   └── [... more orchestrators]
 │   │   │   │       └── [... more platforms]
 │   │   │   ├── update [how to move to newer versions]
-│   │   │   │   ├── methods.markdown [methods and instructions to update]
-│   │   │   │   ├── guidelines.markdown [guidelines and caveats around updating]
-│   │   │   │   └── comparison.markdown [how each method is different]
+│   │   │   │   ├── methods [methods and instructions to update]
+│   │   │   │   ├── guidelines [guidelines and caveats around updating]
+│   │   │   │   └── comparison [how each method is different]
 │   │   │   ├── hardware [topics specific to underlying hardware]
-│   │   │   │   ├── requirements.markdown
+│   │   │   │   ├── requirements
 │   │   │   │   └── [... future hardware related pages] 
 │   │   │   ├── concepts [topics that provide high-level explainations]
-│   │   │   │   ├── image-based-updates.markdown
+│   │   │   │   ├── image-based-updates
 │   │   │   │   └── [... other conceptual pages]
-│   │   │   ├── glossary.markdown [defintions]
+│   │   │   ├── glossary [defintions]
 │   │   │   ├── api [settings avaliable in the api defintions]
 │   │   │   │   ├── endpoints [top-level API endpoints, from the OpenAPI spec]
-│   │   │   │   │   ├── settings.markdown [the available methods at this endpoint]
+│   │   │   │   │   ├── settings [the available methods at this endpoint]
 │   │   │   │   │   └── [... more endpoints]
 │   │   │   │   └── settings [all available settings]
-│   │   │   │       ├── motd.markdown [description of what the motd setting does]
+│   │   │   │       ├── motd [description of what the motd setting does]
 │   │   │   │       └── [... more settings]
-│   │   │   ├── login
-│   │   │   │   ├── control-container.markdown
-│   │   │   │   ├── admin-container.markdown
-│   │   │   │   └── regaining-access.markdown
+│   │   │   └── login
+│   │   │       ├── control-container
+│   │   │       ├── admin-container
+│   │   │       └── regaining-access
 │   │   └── [... more versions]
 │   ├── control-container
 │   │   ├── 0.7.x


### PR DESCRIPTION
**Issue number:**

Closes #39

**Description of changes:**

Switches DIRECTORY-STRUCTURE.md to use directories instead of individual files, and describe why that is the case.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
