### PR TITLE
Adds shortcode for un-versioned links

### DIFF
--- a/content/en/faqitems/access-1-regaining-access.markdown
+++ b/content/en/faqitems/access-1-regaining-access.markdown
@@ -4,4 +4,4 @@ group = "Access"
 +++
 
 There is a way to regain access to a Bottlerocket node in such a state.
-See the [Regaining Access documentation](../os/1.13.x/login/regaining-access) for further details.
+See the {{< ver-ref project="os" page="/login/regaining-access" >}}Regaining Access documentation{{< /ver-ref >}} for further details.

--- a/data/README.md
+++ b/data/README.md
@@ -1,3 +1,0 @@
-# Data
-
-This is a Hugo scaffold directory. See the [hugo docs](https://gohugo.io/getting-started/directory-structure/) for more information.

--- a/data/versions/current.toml
+++ b/data/versions/current.toml
@@ -1,0 +1,4 @@
+[os]
+    major = 1
+    minor = 13
+    patch = 0

--- a/layouts/shortcodes/ver-ref.html
+++ b/layouts/shortcodes/ver-ref.html
@@ -1,0 +1,6 @@
+{{- $project := .Get "project" -}}
+{{- $versionParam := .Get "v" -}}
+{{- $projectVersion := index $.Site.Data.versions.current $project -}}
+{{- $version := cond (eq (len $versionParam) 0 ) (print $projectVersion.major "." $projectVersion.minor ".x" ) $versionParam -}}
+{{- $refpage := .Get "page" }}
+<a href="/{{ $.Page.Language }}/{{$project}}/{{$version}}{{$refpage}}">{{.Inner}}</a>


### PR DESCRIPTION
**Issue number:**

Closes # n/a

**Description of changes:**

This adds the `ver-ref` shortcode that is aware of the site's structure (language, project, versions). So, if you want to create a link to the latest version of a specific file in the docs, you can specify it as so:

```
{{< ver-ref project="os" page="/path/to/page" >}} link text{{< /ver-ref >}}
```

The current version is specified in the `/versions/current` data file on a per project basis.

So, if the current version is set to 1.20.1, the above link will point to `/en/os/1.20.x/path/to/page`. When the next version is released and the `/versions/current` file is changed to 1.21.0, the link will then point to `/en/os/1.21.x/path/to/page`.




**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
