### PR TITLE
directory structure: suggest new packages page

### DIFF
--- a/DIRECTORY-STRUCTURE.md
+++ b/DIRECTORY-STRUCTURE.md
@@ -38,6 +38,9 @@ This may not be comprehensive for every file, but should be considered a living 
 │   │   ├── 1.12.x [versioned content, each new minor version gets a new directrory]
 │   │   │   ├── introduction
 │   │   │   ├── packages [which packages (and which versions) are included in this release]
+│   │   │   │   ├── 1.12.0 [packages and package versions specifically for release 1.12.0]
+│   │   │   │   ├── 1.12.1 [packages and package versions specifically for release 1.12.1]
+│   │   │   │   └── [... more patch releases]
 │   │   │   ├── install [how to put Bottlerocket on a node]
 │   │   │   │   ├── manual [install instructions without high level tools]
 │   │   │   │   │   ├── aws [each platform gets an directory]

--- a/DIRECTORY-STRUCTURE.md
+++ b/DIRECTORY-STRUCTURE.md
@@ -37,6 +37,7 @@ This may not be comprehensive for every file, but should be considered a living 
 │   ├── os [Bottlerocket's documentation]
 │   │   ├── 1.12.x [versioned content, each new minor version gets a new directrory]
 │   │   │   ├── introduction
+│   │   │   ├── packages [which packages (and which versions) are included in this release]
 │   │   │   ├── install [how to put Bottlerocket on a node]
 │   │   │   │   ├── manual [install instructions without high level tools]
 │   │   │   │   │   ├── aws [each platform gets an directory]


### PR DESCRIPTION
**Issue number:**

Related to #14 

**Description of changes:**

Suggests a location for where a new "packages" page should reside.

The "packages" page would contain an inventory (table/list) of all the included software versions for each release.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
