### PR TITLE
adds variant-kernel script, template, readme, and 1.13.x datafiles

### DIFF
--- a/content/en/os/1.13.x/version-information/_index.markdown
+++ b/content/en/os/1.13.x/version-information/_index.markdown
@@ -1,0 +1,5 @@
++++
+title = "Version Information"
+description = "Information specific to this version of Bottlerocket"
+type = "docs"
++++

--- a/content/en/os/1.13.x/version-information/variants/index.markdown
+++ b/content/en/os/1.13.x/version-information/variants/index.markdown
@@ -1,0 +1,7 @@
++++
+title = "Variants & Kernels"
+description = "Kernel versions and parameters specific for each Bottlerocket variant"
+type = "docs"
++++
+{{< page-ver >}}
+{{< kernel-variant-info >}}

--- a/data/variants/1.13.x/aws-dev.toml
+++ b/data/variants/1.13.x/aws-dev.toml
@@ -1,0 +1,59 @@
+# Extracted from https://github.com/bottlerocket-os/bottlerocket/variants/aws-dev/Cargo.toml
+[package]
+name = "aws-dev"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+unified-cgroup-hierarchy = true
+
+[package.metadata.build-variant]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    # Only reserve if there are at least 2GB
+    "crashkernel=2G-:256M",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+included-packages = [
+# core
+    "release",
+    "kernel-5.15",
+# docker
+    "docker-cli",
+    "docker-engine",
+    "docker-init",
+    "docker-proxy",
+# tools
+    "login",
+    "iputils",
+    "strace",
+    "tcpdump",
+    "chrony-tools",
+]
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+# core
+release = { path = "../../packages/release" }
+kernel-5_15 = { path = "../../packages/kernel-5.15" }
+# docker
+docker-cli = { path = "../../packages/docker-cli" }
+docker-engine = { path = "../../packages/docker-engine" }
+docker-init = { path = "../../packages/docker-init" }
+docker-proxy = { path = "../../packages/docker-proxy" }
+# tools
+login = { path = "../../packages/login" }
+iputils = { path = "../../packages/iputils" }
+strace = { path = "../../packages/strace" }
+tcpdump = { path = "../../packages/tcpdump" }
+chrony = { path = "../../packages/chrony" }

--- a/data/variants/1.13.x/aws-ecs-1-nvidia.toml
+++ b/data/variants/1.13.x/aws-ecs-1-nvidia.toml
@@ -1,0 +1,54 @@
+# Extracted from https://github.com/bottlerocket-os/bottlerocket/variants/aws-ecs-1-nvidia/Cargo.toml
+[package]
+name = "aws-ecs-1-nvidia"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+
+[package.metadata.build-variant.image-layout]
+os-image-size-gib = 4
+
+[package.metadata.build-variant]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+included-packages = [
+# core
+    "release",
+    "kernel-5.10",
+# docker
+    "docker-cli",
+    "docker-engine",
+    "docker-init",
+    "docker-proxy",
+# ecs
+    "ecs-agent",
+# NVIDIA support
+    "ecs-gpu-init",
+    "nvidia-container-toolkit",
+    "kmod-5.10-nvidia-tesla-470",
+]
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+# core
+release = { path = "../../packages/release" }
+kernel-5_10 = { path = "../../packages/kernel-5.10" }
+# docker
+docker-cli = { path = "../../packages/docker-cli" }
+docker-engine = { path = "../../packages/docker-engine" }
+docker-init = { path = "../../packages/docker-init" }
+docker-proxy = { path = "../../packages/docker-proxy" }
+# ecs
+ecs-agent = { path = "../../packages/ecs-agent" }
+# NVIDIA
+ecs-gpu-init = { path = "../../packages/ecs-gpu-init" }
+nvidia-container-toolkit = { path = "../../packages/nvidia-container-toolkit" }
+kmod-5_10-nvidia = { path = "../../packages/kmod-5.10-nvidia" }

--- a/data/variants/1.13.x/aws-ecs-1.toml
+++ b/data/variants/1.13.x/aws-ecs-1.toml
@@ -1,0 +1,43 @@
+# Extracted from https://github.com/bottlerocket-os/bottlerocket/variants/aws-ecs-1/Cargo.toml
+[package]
+name = "aws-ecs-1"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+
+[package.metadata.build-variant]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+included-packages = [
+# core
+    "release",
+    "kernel-5.10",
+# docker
+    "docker-cli",
+    "docker-engine",
+    "docker-init",
+    "docker-proxy",
+# ecs
+    "ecs-agent",
+]
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+# core
+release = { path = "../../packages/release" }
+kernel-5_10 = { path = "../../packages/kernel-5.10" }
+# docker
+docker-cli = { path = "../../packages/docker-cli" }
+docker-engine = { path = "../../packages/docker-engine" }
+docker-init = { path = "../../packages/docker-init" }
+docker-proxy = { path = "../../packages/docker-proxy" }
+# ecs
+ecs-agent = { path = "../../packages/ecs-agent" }

--- a/data/variants/1.13.x/aws-k8s-1.22-nvidia.toml
+++ b/data/variants/1.13.x/aws-k8s-1.22-nvidia.toml
@@ -1,0 +1,48 @@
+# Extracted from https://github.com/bottlerocket-os/bottlerocket/variants/aws-k8s-1.22-nvidia/Cargo.toml
+[package]
+# This is the aws-k8s-1.22-nvidia variant.  "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_22-nvidia"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+os-image-size-gib = 4
+
+[package.metadata.build-variant]
+included-packages = [
+    "aws-iam-authenticator",
+    "cni",
+    "cni-plugins",
+    "kernel-5.10",
+    "kubelet-1.22",
+    "release",
+    "nvidia-container-toolkit",
+    "nvidia-k8s-device-plugin",
+    "kmod-5.10-nvidia-tesla-470",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
+cni = { path = "../../packages/cni" }
+cni-plugins = { path = "../../packages/cni-plugins" }
+kernel-5_10 = { path = "../../packages/kernel-5.10" }
+kubernetes-1_22 = { path = "../../packages/kubernetes-1.22" }
+release = { path = "../../packages/release" }
+nvidia-container-toolkit = { path = "../../packages/nvidia-container-toolkit" }
+nvidia-k8s-device-plugin = { path = "../../packages/nvidia-k8s-device-plugin" }
+kmod-5_10-nvidia = { path = "../../packages/kmod-5.10-nvidia" }

--- a/data/variants/1.13.x/aws-k8s-1.22.toml
+++ b/data/variants/1.13.x/aws-k8s-1.22.toml
@@ -1,0 +1,39 @@
+# Extracted from https://github.com/bottlerocket-os/bottlerocket/variants/aws-k8s-1.22/Cargo.toml
+[package]
+# This is the aws-k8s-1.22 variant.  "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_22"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant]
+included-packages = [
+    "aws-iam-authenticator",
+    "cni",
+    "cni-plugins",
+    "kernel-5.10",
+    "kubelet-1.22",
+    "release",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
+cni = { path = "../../packages/cni" }
+cni-plugins = { path = "../../packages/cni-plugins" }
+kernel-5_10 = { path = "../../packages/kernel-5.10" }
+kubernetes-1_22 = { path = "../../packages/kubernetes-1.22" }
+release = { path = "../../packages/release" }

--- a/data/variants/1.13.x/aws-k8s-1.23-nvidia.toml
+++ b/data/variants/1.13.x/aws-k8s-1.23-nvidia.toml
@@ -1,0 +1,51 @@
+# Extracted from https://github.com/bottlerocket-os/bottlerocket/variants/aws-k8s-1.23-nvidia/Cargo.toml
+[package]
+# This is the aws-k8s-1.23-nvidia variant.  "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_23-nvidia"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+os-image-size-gib = 4
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+
+[package.metadata.build-variant]
+included-packages = [
+    "aws-iam-authenticator",
+    "cni",
+    "cni-plugins",
+    "kernel-5.10",
+    "kubelet-1.23",
+    "release",
+    "nvidia-container-toolkit",
+    "nvidia-k8s-device-plugin",
+    "kmod-5.10-nvidia-tesla-470",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
+cni = { path = "../../packages/cni" }
+cni-plugins = { path = "../../packages/cni-plugins" }
+kernel-5_10 = { path = "../../packages/kernel-5.10" }
+kubernetes-1_23 = { path = "../../packages/kubernetes-1.23" }
+release = { path = "../../packages/release" }
+nvidia-container-toolkit = { path = "../../packages/nvidia-container-toolkit" }
+nvidia-k8s-device-plugin = { path = "../../packages/nvidia-k8s-device-plugin" }
+kmod-5_10-nvidia = { path = "../../packages/kmod-5.10-nvidia" }

--- a/data/variants/1.13.x/aws-k8s-1.23.toml
+++ b/data/variants/1.13.x/aws-k8s-1.23.toml
@@ -1,0 +1,42 @@
+# Extracted from https://github.com/bottlerocket-os/bottlerocket/variants/aws-k8s-1.23/Cargo.toml
+[package]
+# This is the aws-k8s-1.23 variant.  "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_23"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+
+[package.metadata.build-variant]
+included-packages = [
+    "aws-iam-authenticator",
+    "cni",
+    "cni-plugins",
+    "kernel-5.10",
+    "kubelet-1.23",
+    "release",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
+cni = { path = "../../packages/cni" }
+cni-plugins = { path = "../../packages/cni-plugins" }
+kernel-5_10 = { path = "../../packages/kernel-5.10" }
+kubernetes-1_23= { path = "../../packages/kubernetes-1.23" }
+release = { path = "../../packages/release" }

--- a/data/variants/1.13.x/aws-k8s-1.24-nvidia.toml
+++ b/data/variants/1.13.x/aws-k8s-1.24-nvidia.toml
@@ -1,0 +1,51 @@
+# Extracted from https://github.com/bottlerocket-os/bottlerocket/variants/aws-k8s-1.24-nvidia/Cargo.toml
+[package]
+# This is the aws-k8s-1.24-nvidia variant.  "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_24-nvidia"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+os-image-size-gib = 4
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+
+[package.metadata.build-variant]
+included-packages = [
+    "aws-iam-authenticator",
+    "cni",
+    "cni-plugins",
+    "kernel-5.15",
+    "kubelet-1.24",
+    "release",
+    "nvidia-container-toolkit",
+    "nvidia-k8s-device-plugin",
+    "kmod-5.15-nvidia-tesla-515",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
+cni = { path = "../../packages/cni" }
+cni-plugins = { path = "../../packages/cni-plugins" }
+kernel-5_15 = { path = "../../packages/kernel-5.15" }
+kubernetes-1_24 = { path = "../../packages/kubernetes-1.24" }
+release = { path = "../../packages/release" }
+nvidia-container-toolkit = { path = "../../packages/nvidia-container-toolkit" }
+nvidia-k8s-device-plugin = { path = "../../packages/nvidia-k8s-device-plugin" }
+kmod-5_15-nvidia = { path = "../../packages/kmod-5.15-nvidia" }

--- a/data/variants/1.13.x/aws-k8s-1.24.toml
+++ b/data/variants/1.13.x/aws-k8s-1.24.toml
@@ -1,0 +1,42 @@
+# Extracted from https://github.com/bottlerocket-os/bottlerocket/variants/aws-k8s-1.24/Cargo.toml
+[package]
+# This is the aws-k8s-1.24 variant.  "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_24"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+
+[package.metadata.build-variant]
+included-packages = [
+    "aws-iam-authenticator",
+    "cni",
+    "cni-plugins",
+    "kernel-5.15",
+    "kubelet-1.24",
+    "release",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
+cni = { path = "../../packages/cni" }
+cni-plugins = { path = "../../packages/cni-plugins" }
+kernel-5_15 = { path = "../../packages/kernel-5.15" }
+kubernetes-1_24= { path = "../../packages/kubernetes-1.24" }
+release = { path = "../../packages/release" }

--- a/data/variants/1.13.x/aws-k8s-1.25-nvidia.toml
+++ b/data/variants/1.13.x/aws-k8s-1.25-nvidia.toml
@@ -1,0 +1,51 @@
+# Extracted from https://github.com/bottlerocket-os/bottlerocket/variants/aws-k8s-1.25-nvidia/Cargo.toml
+[package]
+# This is the aws-k8s-1.25-nvidia variant. "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_25-nvidia"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+os-image-size-gib = 4
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+
+[package.metadata.build-variant]
+included-packages = [
+    "aws-iam-authenticator",
+    "cni",
+    "cni-plugins",
+    "kernel-5.15",
+    "kubelet-1.25",
+    "release",
+    "nvidia-container-toolkit",
+    "nvidia-k8s-device-plugin",
+    "kmod-5.15-nvidia-tesla-515",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
+cni = { path = "../../packages/cni" }
+cni-plugins = { path = "../../packages/cni-plugins" }
+kernel-5_15 = { path = "../../packages/kernel-5.15" }
+kubernetes-1_25 = { path = "../../packages/kubernetes-1.25" }
+release = { path = "../../packages/release" }
+nvidia-container-toolkit = { path = "../../packages/nvidia-container-toolkit" }
+nvidia-k8s-device-plugin = { path = "../../packages/nvidia-k8s-device-plugin" }
+kmod-5_15-nvidia = { path = "../../packages/kmod-5.15-nvidia" }

--- a/data/variants/1.13.x/aws-k8s-1.25.toml
+++ b/data/variants/1.13.x/aws-k8s-1.25.toml
@@ -1,0 +1,42 @@
+# Extracted from https://github.com/bottlerocket-os/bottlerocket/variants/aws-k8s-1.25/Cargo.toml
+[package]
+# This is the aws-k8s-1.25 variant. "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_25"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+
+[package.metadata.build-variant]
+included-packages = [
+    "aws-iam-authenticator",
+    "cni",
+    "cni-plugins",
+    "kernel-5.15",
+    "kubelet-1.25",
+    "release",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
+cni = { path = "../../packages/cni" }
+cni-plugins = { path = "../../packages/cni-plugins" }
+kernel-5_15 = { path = "../../packages/kernel-5.15" }
+kubernetes-1_25 = { path = "../../packages/kubernetes-1.25" }
+release = { path = "../../packages/release" }

--- a/data/variants/1.13.x/aws-k8s-1.26-nvidia.toml
+++ b/data/variants/1.13.x/aws-k8s-1.26-nvidia.toml
@@ -1,0 +1,52 @@
+# Extracted from https://github.com/bottlerocket-os/bottlerocket/variants/aws-k8s-1.26-nvidia/Cargo.toml
+[package]
+# This is the aws-k8s-1.26-nvidia variant. "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_26-nvidia"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+os-image-size-gib = 4
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+unified-cgroup-hierarchy = true
+
+[package.metadata.build-variant]
+included-packages = [
+    "aws-iam-authenticator",
+    "cni",
+    "cni-plugins",
+    "kernel-5.15",
+    "kubelet-1.26",
+    "release",
+    "nvidia-container-toolkit",
+    "nvidia-k8s-device-plugin",
+    "kmod-5.15-nvidia-tesla-515",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
+cni = { path = "../../packages/cni" }
+cni-plugins = { path = "../../packages/cni-plugins" }
+kernel-5_15 = { path = "../../packages/kernel-5.15" }
+kubernetes-1_26 = { path = "../../packages/kubernetes-1.26" }
+release = { path = "../../packages/release" }
+nvidia-container-toolkit = { path = "../../packages/nvidia-container-toolkit" }
+nvidia-k8s-device-plugin = { path = "../../packages/nvidia-k8s-device-plugin" }
+kmod-5_15-nvidia = { path = "../../packages/kmod-5.15-nvidia" }

--- a/data/variants/1.13.x/aws-k8s-1.26.toml
+++ b/data/variants/1.13.x/aws-k8s-1.26.toml
@@ -1,0 +1,43 @@
+# Extracted from https://github.com/bottlerocket-os/bottlerocket/variants/aws-k8s-1.26/Cargo.toml
+[package]
+# This is the aws-k8s-1.26 variant. "." is not allowed in crate names, but we
+# don't use this crate name anywhere.
+name = "aws-k8s-1_26"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+unified-cgroup-hierarchy = true
+
+[package.metadata.build-variant]
+included-packages = [
+    "aws-iam-authenticator",
+    "cni",
+    "cni-plugins",
+    "kernel-5.15",
+    "kubelet-1.26",
+    "release",
+]
+kernel-parameters = [
+    "console=tty0",
+    "console=ttyS0,115200n8",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+aws-iam-authenticator = { path = "../../packages/aws-iam-authenticator" }
+cni = { path = "../../packages/cni" }
+cni-plugins = { path = "../../packages/cni-plugins" }
+kernel-5_15 = { path = "../../packages/kernel-5.15" }
+kubernetes-1_26 = { path = "../../packages/kubernetes-1.26" }
+release = { path = "../../packages/release" }

--- a/data/variants/1.13.x/metal-dev.toml
+++ b/data/variants/1.13.x/metal-dev.toml
@@ -1,0 +1,58 @@
+# Extracted from https://github.com/bottlerocket-os/bottlerocket/variants/metal-dev/Cargo.toml
+[package]
+name = "metal-dev"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+partition-plan = "unified"
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+unified-cgroup-hierarchy = true
+
+[package.metadata.build-variant]
+image-format = "raw"
+kernel-parameters = [
+    # Only reserve if there are at least 2GB
+    "crashkernel=2G-:256M"
+]
+included-packages = [
+# core
+    "release",
+    "kernel-5.15",
+# docker
+    "docker-cli",
+    "docker-engine",
+    "docker-init",
+    "docker-proxy",
+# tools
+    "login",
+    "iputils",
+    "strace",
+    "tcpdump",
+    "chrony-tools",
+]
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+# core
+release = { path = "../../packages/release" }
+kernel-5_15 = { path = "../../packages/kernel-5.15" }
+# docker
+docker-cli = { path = "../../packages/docker-cli" }
+docker-engine = { path = "../../packages/docker-engine" }
+docker-init = { path = "../../packages/docker-init" }
+docker-proxy = { path = "../../packages/docker-proxy" }
+# tools
+login = { path = "../../packages/login" }
+iputils = { path = "../../packages/iputils" }
+strace = { path = "../../packages/strace" }
+tcpdump = { path = "../../packages/tcpdump" }
+chrony = { path = "../../packages/chrony" }

--- a/data/variants/1.13.x/metal-k8s-1.22.toml
+++ b/data/variants/1.13.x/metal-k8s-1.22.toml
@@ -1,0 +1,43 @@
+# Extracted from https://github.com/bottlerocket-os/bottlerocket/variants/metal-k8s-1.22/Cargo.toml
+[package]
+# This is the metal-k8s-1.22 variant.  "." is not allowed in crate names, but
+# we don't use this crate name anywhere.
+name = "metal-k8s-1_22"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+os-image-size-gib = 4
+partition-plan = "unified"
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+
+[package.metadata.build-variant]
+image-format = "raw"
+supported-arches = ["x86_64"]
+kernel-parameters = [
+    # Only reserve if there are at least 2GB
+    "crashkernel=2G-:256M"
+]
+included-packages = [
+    "cni",
+    "cni-plugins",
+    "kernel-5.10",
+    "kubelet-1.22",
+    "release",
+]
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+cni = { path = "../../packages/cni" }
+cni-plugins = { path = "../../packages/cni-plugins" }
+kernel-5_10 = { path = "../../packages/kernel-5.10" }
+kubernetes-1_22 = { path = "../../packages/kubernetes-1.22" }
+release = { path = "../../packages/release" }

--- a/data/variants/1.13.x/metal-k8s-1.23.toml
+++ b/data/variants/1.13.x/metal-k8s-1.23.toml
@@ -1,0 +1,43 @@
+# Extracted from https://github.com/bottlerocket-os/bottlerocket/variants/metal-k8s-1.23/Cargo.toml
+[package]
+# This is the metal-k8s-1.23 variant.  "." is not allowed in crate names, but
+# we don't use this crate name anywhere.
+name = "metal-k8s-1_23"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+os-image-size-gib = 4
+partition-plan = "unified"
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+
+[package.metadata.build-variant]
+image-format = "raw"
+supported-arches = ["x86_64"]
+kernel-parameters = [
+    # Only reserve if there are at least 2GB
+    "crashkernel=2G-:256M"
+]
+included-packages = [
+    "cni",
+    "cni-plugins",
+    "kernel-5.10",
+    "kubelet-1.23",
+    "release",
+]
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+cni = { path = "../../packages/cni" }
+cni-plugins = { path = "../../packages/cni-plugins" }
+kernel-5_10 = { path = "../../packages/kernel-5.10" }
+kubernetes-1_23 = { path = "../../packages/kubernetes-1.23" }
+release = { path = "../../packages/release" }

--- a/data/variants/1.13.x/metal-k8s-1.24.toml
+++ b/data/variants/1.13.x/metal-k8s-1.24.toml
@@ -1,0 +1,43 @@
+# Extracted from https://github.com/bottlerocket-os/bottlerocket/variants/metal-k8s-1.24/Cargo.toml
+[package]
+# This is the metal-k8s-1.24 variant.  "." is not allowed in crate names, but
+# we don't use this crate name anywhere.
+name = "metal-k8s-1_24"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+os-image-size-gib = 4
+partition-plan = "unified"
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+
+[package.metadata.build-variant]
+image-format = "raw"
+supported-arches = ["x86_64"]
+kernel-parameters = [
+    # Only reserve if there are at least 2GB
+    "crashkernel=2G-:256M"
+]
+included-packages = [
+    "cni",
+    "cni-plugins",
+    "kernel-5.15",
+    "kubelet-1.24",
+    "release",
+]
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+cni = { path = "../../packages/cni" }
+cni-plugins = { path = "../../packages/cni-plugins" }
+kernel-5_15 = { path = "../../packages/kernel-5.15" }
+kubernetes-1_24 = { path = "../../packages/kubernetes-1.24" }
+release = { path = "../../packages/release" }

--- a/data/variants/1.13.x/metal-k8s-1.25.toml
+++ b/data/variants/1.13.x/metal-k8s-1.25.toml
@@ -1,0 +1,43 @@
+# Extracted from https://github.com/bottlerocket-os/bottlerocket/variants/metal-k8s-1.25/Cargo.toml
+[package]
+# This is the metal-k8s-1.25 variant. "." is not allowed in crate names, but
+# we don't use this crate name anywhere.
+name = "metal-k8s-1_25"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+os-image-size-gib = 4
+partition-plan = "unified"
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+
+[package.metadata.build-variant]
+image-format = "raw"
+supported-arches = ["x86_64"]
+kernel-parameters = [
+    # Only reserve if there are at least 2GB
+    "crashkernel=2G-:256M"
+]
+included-packages = [
+    "cni",
+    "cni-plugins",
+    "kernel-5.15",
+    "kubelet-1.25",
+    "release",
+]
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+cni = { path = "../../packages/cni" }
+cni-plugins = { path = "../../packages/cni-plugins" }
+kernel-5_15 = { path = "../../packages/kernel-5.15" }
+kubernetes-1_25 = { path = "../../packages/kubernetes-1.25" }
+release = { path = "../../packages/release" }

--- a/data/variants/1.13.x/metal-k8s-1.26.toml
+++ b/data/variants/1.13.x/metal-k8s-1.26.toml
@@ -1,0 +1,44 @@
+# Extracted from https://github.com/bottlerocket-os/bottlerocket/variants/metal-k8s-1.26/Cargo.toml
+[package]
+# This is the metal-k8s-1.26 variant. "." is not allowed in crate names, but
+# we don't use this crate name anywhere.
+name = "metal-k8s-1_26"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+os-image-size-gib = 4
+partition-plan = "unified"
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+unified-cgroup-hierarchy = true
+
+[package.metadata.build-variant]
+image-format = "raw"
+supported-arches = ["x86_64"]
+kernel-parameters = [
+    # Only reserve if there are at least 2GB
+    "crashkernel=2G-:256M"
+]
+included-packages = [
+    "cni",
+    "cni-plugins",
+    "kernel-5.15",
+    "kubelet-1.26",
+    "release",
+]
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+cni = { path = "../../packages/cni" }
+cni-plugins = { path = "../../packages/cni-plugins" }
+kernel-5_15 = { path = "../../packages/kernel-5.15" }
+kubernetes-1_26 = { path = "../../packages/kubernetes-1.26" }
+release = { path = "../../packages/release" }

--- a/data/variants/1.13.x/vmware-dev.toml
+++ b/data/variants/1.13.x/vmware-dev.toml
@@ -1,0 +1,65 @@
+# Extracted from https://github.com/bottlerocket-os/bottlerocket/variants/vmware-dev/Cargo.toml
+[package]
+name = "vmware-dev"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+partition-plan = "unified"
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+unified-cgroup-hierarchy = true
+
+[package.metadata.build-variant]
+image-format = "vmdk"
+supported-arches = ["x86_64"]
+kernel-parameters = [
+    "console=tty1",
+    # Only reserve if there are at least 2GB
+    "crashkernel=2G-:256M",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+included-packages = [
+# core
+    "release",
+    "kernel-5.15",
+    "open-vm-tools",
+# docker
+    "docker-cli",
+    "docker-engine",
+    "docker-init",
+    "docker-proxy",
+# tools
+    "login",
+    "iputils",
+    "strace",
+    "tcpdump",
+    "chrony-tools",
+]
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+# core
+release = { path = "../../packages/release" }
+kernel-5_15 = { path = "../../packages/kernel-5.15" }
+open-vm-tools = { path = "../../packages/open-vm-tools" }
+# docker
+docker-cli = { path = "../../packages/docker-cli" }
+docker-engine = { path = "../../packages/docker-engine" }
+docker-init = { path = "../../packages/docker-init" }
+docker-proxy = { path = "../../packages/docker-proxy" }
+# tools
+login = { path = "../../packages/login" }
+iputils = { path = "../../packages/iputils" }
+strace = { path = "../../packages/strace" }
+tcpdump = { path = "../../packages/tcpdump" }
+chrony = { path = "../../packages/chrony" }

--- a/data/variants/1.13.x/vmware-k8s-1.22.toml
+++ b/data/variants/1.13.x/vmware-k8s-1.22.toml
@@ -1,0 +1,45 @@
+# Extracted from https://github.com/bottlerocket-os/bottlerocket/variants/vmware-k8s-1.22/Cargo.toml
+[package]
+# This is the vmware-k8s-1.22 variant.  "." is not allowed in crate names, but
+# we don't use this crate name anywhere.
+name = "vmware-k8s-1_22"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+partition-plan = "unified"
+
+[package.metadata.build-variant]
+image-format = "vmdk"
+supported-arches = ["x86_64"]
+kernel-parameters = [
+    "console=tty1",
+    # Only reserve if there are at least 2GB
+    "crashkernel=2G-:256M",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+included-packages = [
+    "cni",
+    "cni-plugins",
+    "kernel-5.10",
+    "kubelet-1.22",
+    "open-vm-tools",
+    "release",
+]
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+cni = { path = "../../packages/cni" }
+cni-plugins = { path = "../../packages/cni-plugins" }
+kernel-5_10 = { path = "../../packages/kernel-5.10" }
+kubernetes-1_22 = { path = "../../packages/kubernetes-1.22" }
+open-vm-tools = { path = "../../packages/open-vm-tools" }
+release = { path = "../../packages/release" }

--- a/data/variants/1.13.x/vmware-k8s-1.23.toml
+++ b/data/variants/1.13.x/vmware-k8s-1.23.toml
@@ -1,0 +1,48 @@
+# Extracted from https://github.com/bottlerocket-os/bottlerocket/variants/vmware-k8s-1.23/Cargo.toml
+[package]
+# This is the vmware-k8s-1.23 variant.  "." is not allowed in crate names, but
+# we don't use this crate name anywhere.
+name = "vmware-k8s-1_23"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+partition-plan = "unified"
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+
+[package.metadata.build-variant]
+image-format = "vmdk"
+supported-arches = ["x86_64"]
+kernel-parameters = [
+    "console=tty1",
+    # Only reserve if there are at least 2GB
+    "crashkernel=2G-:256M",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+included-packages = [
+    "cni",
+    "cni-plugins",
+    "kernel-5.10",
+    "kubelet-1.23",
+    "open-vm-tools",
+    "release",
+]
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+cni = { path = "../../packages/cni" }
+cni-plugins = { path = "../../packages/cni-plugins" }
+kernel-5_10 = { path = "../../packages/kernel-5.10" }
+kubernetes-1_23 = { path = "../../packages/kubernetes-1.23" }
+open-vm-tools = { path = "../../packages/open-vm-tools" }
+release = { path = "../../packages/release" }

--- a/data/variants/1.13.x/vmware-k8s-1.24.toml
+++ b/data/variants/1.13.x/vmware-k8s-1.24.toml
@@ -1,0 +1,48 @@
+# Extracted from https://github.com/bottlerocket-os/bottlerocket/variants/vmware-k8s-1.24/Cargo.toml
+[package]
+# This is the vmware-k8s-1.24 variant.  "." is not allowed in crate names, but
+# we don't use this crate name anywhere.
+name = "vmware-k8s-1_24"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+partition-plan = "unified"
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+
+[package.metadata.build-variant]
+image-format = "vmdk"
+supported-arches = ["x86_64"]
+kernel-parameters = [
+    "console=tty1",
+    # Only reserve if there are at least 2GB
+    "crashkernel=2G-:256M",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+included-packages = [
+    "cni",
+    "cni-plugins",
+    "kernel-5.15",
+    "kubelet-1.24",
+    "open-vm-tools",
+    "release",
+]
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+cni = { path = "../../packages/cni" }
+cni-plugins = { path = "../../packages/cni-plugins" }
+kernel-5_15 = { path = "../../packages/kernel-5.15" }
+kubernetes-1_24 = { path = "../../packages/kubernetes-1.24" }
+open-vm-tools = { path = "../../packages/open-vm-tools" }
+release = { path = "../../packages/release" }

--- a/data/variants/1.13.x/vmware-k8s-1.25.toml
+++ b/data/variants/1.13.x/vmware-k8s-1.25.toml
@@ -1,0 +1,48 @@
+# Extracted from https://github.com/bottlerocket-os/bottlerocket/variants/vmware-k8s-1.25/Cargo.toml
+[package]
+# This is the vmware-k8s-1.25 variant. "." is not allowed in crate names, but
+# we don't use this crate name anywhere.
+name = "vmware-k8s-1_25"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+partition-plan = "unified"
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+
+[package.metadata.build-variant]
+image-format = "vmdk"
+supported-arches = ["x86_64"]
+kernel-parameters = [
+    "console=tty1",
+    # Only reserve if there are at least 2GB
+    "crashkernel=2G-:256M",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+included-packages = [
+    "cni",
+    "cni-plugins",
+    "kernel-5.15",
+    "kubelet-1.25",
+    "open-vm-tools",
+    "release",
+]
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+cni = { path = "../../packages/cni" }
+cni-plugins = { path = "../../packages/cni-plugins" }
+kernel-5_15 = { path = "../../packages/kernel-5.15" }
+kubernetes-1_25 = { path = "../../packages/kubernetes-1.25" }
+open-vm-tools = { path = "../../packages/open-vm-tools" }
+release = { path = "../../packages/release" }

--- a/data/variants/1.13.x/vmware-k8s-1.26.toml
+++ b/data/variants/1.13.x/vmware-k8s-1.26.toml
@@ -1,0 +1,49 @@
+# Extracted from https://github.com/bottlerocket-os/bottlerocket/variants/vmware-k8s-1.26/Cargo.toml
+[package]
+# This is the vmware-k8s-1.26 variant. "." is not allowed in crate names, but
+# we don't use this crate name anywhere.
+name = "vmware-k8s-1_26"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[package.metadata.build-variant.image-layout]
+partition-plan = "unified"
+
+[package.metadata.build-variant.image-features]
+grub-set-private-var = true
+unified-cgroup-hierarchy = true
+
+[package.metadata.build-variant]
+image-format = "vmdk"
+supported-arches = ["x86_64"]
+kernel-parameters = [
+    "console=tty1",
+    # Only reserve if there are at least 2GB
+    "crashkernel=2G-:256M",
+    "net.ifnames=0",
+    "netdog.default-interface=eth0:dhcp4,dhcp6?",
+    "quiet",
+]
+included-packages = [
+    "cni",
+    "cni-plugins",
+    "kernel-5.15",
+    "kubelet-1.26",
+    "open-vm-tools",
+    "release",
+]
+
+[lib]
+path = "lib.rs"
+
+[build-dependencies]
+cni = { path = "../../packages/cni" }
+cni-plugins = { path = "../../packages/cni-plugins" }
+kernel-5_15 = { path = "../../packages/kernel-5.15" }
+kubernetes-1_26 = { path = "../../packages/kubernetes-1.26" }
+open-vm-tools = { path = "../../packages/open-vm-tools" }
+release = { path = "../../packages/release" }

--- a/layouts/shortcodes/kernel-variant-info.html
+++ b/layouts/shortcodes/kernel-variant-info.html
@@ -1,0 +1,26 @@
+{{ $project_version := .Page.Scratch.Get "projectVer" }}
+{{ $release_version := replace $project_version "x" "*" }}
+{{ with  $.Site.Data.variants }}
+    {{ $release_variants := index $.Site.Data.variants $project_version }}
+    <table class="table">
+        <thead>
+            <tr>
+                <th scope="col">Variant</th>
+                <th scope="col">Kernel Version</th>
+                <th scope="col">Kernel Parameters</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{ range $release_variants }}
+            <tr>
+                <td><code>{{ replace .package.name "_" "." }}-*-{{ $release_version }}</code></td>
+                {{ range .package.metadata }}
+                <td>{{ $packages := index . "included-packages" }}{{ range $packages }}{{ substr (cond (hasPrefix . "kernel") . "") 7 }}{{ end }}</td>
+                <td>{{ $parameters := index . "kernel-parameters"}}
+                    {{ range $parameters }}<code>{{ . }}</code></br>{{end}}</td>
+                {{ end }}
+            </tr>
+            {{ end }}
+        </tbody>
+    </table>
+{{ end }}

--- a/layouts/shortcodes/page-ver.html
+++ b/layouts/shortcodes/page-ver.html
@@ -1,0 +1,3 @@
+{{ $pathParts := split .Page.File.Path "/" }}
+{{ .Page.Scratch.Set "projectDocs" (index $pathParts 0) }}
+{{ .Page.Scratch.Set "projectVer" (index $pathParts 1) }}

--- a/scripts/variant-kernel/README.md
+++ b/scripts/variant-kernel/README.md
@@ -1,0 +1,39 @@
+# Script: Variant Kernel Information
+
+This script is used to generate the data for `[lang]/os/[version]]/version-information/variants/`. You will need to run it on ever minor version.
+
+
+## Prerequisites
+
+This script works on Linux or MacOS and is unlikely to work in Windows. The directory structure used in the script specifically ties to bottlerocket-os/bottlerocket; it's unlikely to work in any other context.
+
+Before you begin, clone bottlerocket-os/bottlerocket outside the project-website directory.
+
+## Running the scripts
+
+There are two scripts in this directory:
+
+- `get_cargos.sh`: find all the variant's `Cargo.toml` files inside the [bottlerocket repo](https://github.com/bottlerocket-os/bottlerocket/tree/develop/variants) and run `create_data_file_from_cargo.sh` on each.
+- `create_data_file_from_cargo.sh`: Read a single `Cargo.toml` file and copy/transform it into a hugo data file.
+
+If you are experimenting, you probably want to use `create_data_file_from_cargo.sh` as this will create a single file rather than multiple.
+
+### Copy/transform a single `Cargo.toml` into a hugo data file
+
+As an example, if you want to create a hugo data file for the `aws-k8s-1.26` variant you can run the following:
+
+```bash
+./create_data_file_from_cargo.sh /path/to/bottlerocket-repo/variants/aws-k8s-1.26/Cargo.toml /path/to/website/data/variants/1.13.x/
+```
+
+The last part (`/data/variants/1.13.x/`) is relevant and should only be changed based on the version. The trailing slash is also required. This will put a single file `path/to/website/data/variants/1.13.x/aws-k8s-1.26.toml` that is an annoated version of `/path/to/bottlerocket-repo/variants/aws-k8s-1.26/Cargo.toml`.
+
+### Copy/transform all `Cargo.toml` files into a hugo data files
+
+To avoid needing to run the previous script multiple times, the `get_cargos.sh` script is included. It will find all the `Cargo.toml` files in the specified path and run `create_data_file_from_cargo.sh` for each.
+
+```bash
+./get_cargos.sh /path/to/bottlerocket-repo/variants /path/to/website/data/variants/1.13.x/
+```
+
+This will create a new data file for each variant in `/path/to/bottlerocket-repo/variants`.

--- a/scripts/variant-kernel/README.md
+++ b/scripts/variant-kernel/README.md
@@ -1,7 +1,6 @@
 # Script: Variant Kernel Information
 
-This script is used to generate the data for `[lang]/os/[version]]/version-information/variants/`. You will need to run it on ever minor version.
-
+This script is used to generate the data for `[lang]/os/[version]/version-information/variants/`. You will need to run it on every minor version.
 
 ## Prerequisites
 
@@ -26,7 +25,7 @@ As an example, if you want to create a hugo data file for the `aws-k8s-1.26` var
 ./create_data_file_from_cargo.sh /path/to/bottlerocket-repo/variants/aws-k8s-1.26/Cargo.toml /path/to/website/data/variants/1.13.x/
 ```
 
-The last part (`/data/variants/1.13.x/`) is relevant and should only be changed based on the version. The trailing slash is also required. This will put a single file `path/to/website/data/variants/1.13.x/aws-k8s-1.26.toml` that is an annoated version of `/path/to/bottlerocket-repo/variants/aws-k8s-1.26/Cargo.toml`.
+The last part (`/data/variants/1.13.x/`) is relevant and should only be changed based on the version. The trailing slash is also required. This will put a single file `path/to/website/data/variants/1.13.x/aws-k8s-1.26.toml` that is an annotated version of `/path/to/bottlerocket-repo/variants/aws-k8s-1.26/Cargo.toml`.
 
 ### Copy/transform all `Cargo.toml` files into a hugo data files
 

--- a/scripts/variant-kernel/create_data_file_from_cargo.sh
+++ b/scripts/variant-kernel/create_data_file_from_cargo.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+FNAME="$(echo $1 | awk -F/ '{print $(NF-1)}')"
+EXTRACTED="# Extracted from https://github.com/bottlerocket-os/bottlerocket/variants/$FNAME/Cargo.toml"
+if [ "$FNAME" != "variants" ]
+then
+	echo $EXTRACTED > $2$FNAME.toml
+	cat $1 >> $2$FNAME.toml
+fi

--- a/scripts/variant-kernel/get_cargos.sh
+++ b/scripts/variant-kernel/get_cargos.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+find $1/* -name "Cargo.toml" -exec bash create_data_file_from_cargo.sh {} $2  \;


### PR DESCRIPTION
**Issue number:**

Closes # n/a

**Description of changes:**
Adds:
- Script to extract `Cargo.toml` files from bottlerocket-os/bottlerocket
- Script to transform the `Cargo.toml' file to Hugo datafile
- Data files for 1.13.x
- Shortcode for rendering the variant/kernel parameters and versions
- Layouts for variant pages
- Shortcode to inject current version into page Scratch

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
