### PR TITLE
Adds explaination of OS section, subsection-list shortcode

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -185,3 +185,11 @@ header,
 h1,h2,h3,h4,h5,h6 {
     font-family: 'IBM Plex Sans Condensed', sans-serif;
 }
+
+/* this is used to replace the existing section index on section listing pages. Only the explicit one will be shown. */
+.suppress_section_listing .section-index {
+    display: none;
+    &.subsection-list {
+        display: inherit;
+    }
+}

--- a/content/en/os/_index.markdown
+++ b/content/en/os/_index.markdown
@@ -1,4 +1,23 @@
 +++
 title="OS"
 type="docs"
+description="Documentation for the Bottlerocket operating system"
+body_class="suppress_section_listing"
+
 +++
+
+This section covers installing and using the Bottlerocket operating system[^1]. If you’re looking for information on building, contributing to, or learning about the inner workings of Bottlerocket, the [GitHub repo](https://github.com/bottlerocket/bottlerocket-os) has more information.
+
+## Organization
+
+The Bottlerocket documentation is organized by minor version, with each minor release getting it’s own namespaced, version-specific section. Inside each version-specific sections are subsections which address specific tasks or categories of information.
+
+The current documented versions:
+
+{{< subsections-list >}}
+
+## Something Missing?
+
+Bottlerocket, like any operating system, is complex and rich with options and configuration. This [documentation is open-source](https://github.com/bottlerocket-os/project-website) and likely incomplete, but will evolve over time to encompass a more complete explanation of the software. Should you find gaps, you’re invited to file issues or contribute.
+
+[^1]: Documentation for projects related to Bottlerocket (such as the Control Container, Admin Container, brupop, etc.) are not present in this documentation and still reside in their respective GitHub repos. In the future, documentation on the use and installation of these tools will migrate to a new section on this site.

--- a/layouts/shortcodes/subsections-list.html
+++ b/layouts/shortcodes/subsections-list.html
@@ -1,0 +1,8 @@
+
+<div class="section-index subsection-list">
+    <div class="entry">
+        {{ range (.Page.Pages)  }}
+            <h5><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h5>
+        {{ end }}
+    </div>
+</div>


### PR DESCRIPTION
**Issue number:**

Closes #65

**Description of changes:**
- Adds an explanation to the section page for OS
- Adds a shortcode called "subsections-list" that allows for relocating the listing the sections page to anywhere in the context
- Adds supporting styles for the shortcode

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
