### PR TITLE
variants: "arm64" to "aarch64"

### DIFF
--- a/content/en/os/1.13.x/concepts/variants/index.markdown
+++ b/content/en/os/1.13.x/concepts/variants/index.markdown
@@ -9,7 +9,7 @@ This allows the distribution to ship a limited set of drivers, tools, and applic
 
 Bottlerocket is not a general purpose Linux distribution and intentionally doesn’t have a package manager. Instead Bottlerocket has *variants*.
 Variants are pre-defined sets of drivers, tools, and applications that are tailored to a specific architecture, platform, and orchestrator (as well as a “flavor,” more on that later).
-For example, there is a variant that consists of everything needed to run as a Kubernetes (orchestrator) node on an arm64 (architecture) processor in AWS EC2 (platform).
+For example, there is a variant that consists of everything needed to run as a Kubernetes (orchestrator) node on an aarch64 (architecture) processor in AWS EC2 (platform).
 Bottlerocket delivers the variant as a complete, ready-to-run image.
 
 Variants may be specific to particular versions of the orchestrator. 
@@ -34,11 +34,11 @@ The components in the file name follow a specific order:
 [platform]-[orchestrator]-[orchestrator version](optional:-[ flavour])-[Architecture]-[version]-[commit]
 ```
 
-Example: `bottlerocket-aws-k8s-1.25-nvidia-arm64-1.13.0...`
+Example: `bottlerocket-aws-k8s-1.25-nvidia-aarch64-1.13.0...`
 
 |Platform|Orchestrator|Orchestrator Version|Flavor|Architecture|Bottlerocket version|
 |---|---|---|---|---|---|
-|`aws`|`k8s`|`1.25`|`nvidia`|`arm64`|`1.13.0`|
+|`aws`|`k8s`|`1.25`|`nvidia`|`aarch64`|`1.13.0`|
 
 Example: `bottlerocket-vmware-k8s-1.24-x86_64-1.12...`
 


### PR DESCRIPTION
**Issue number:**

Closes #68 

**Description of changes:**

Changes `arm64` to `aarch64` to accurately show the Bottlerocket variant naming convention.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
