### PR TITLE
host containers: add ECS output

### DIFF
--- a/content/en/os/1.13.x/install/quickstart/aws/host-containers/index.markdown
+++ b/content/en/os/1.13.x/install/quickstart/aws/host-containers/index.markdown
@@ -100,7 +100,17 @@ SUPPORT_URL="https://github.com/bottlerocket-os/bottlerocket/discussions"
 BUG_REPORT_URL="https://github.com/bottlerocket-os/bottlerocket/issues"
   {{< /tab >}}
   {{< tab header="ECS" >}}
-ECS content goes here
+[root@admin]# cat /.bottlerocket/rootfs/etc/os-release
+NAME=Bottlerocket
+ID=bottlerocket
+VERSION="1.13.1 (aws-ecs-1)"
+PRETTY_NAME="Bottlerocket OS 1.13.1 (aws-ecs-1)"
+VARIANT_ID=aws-ecs-1
+VERSION_ID=1.13.1
+BUILD_ID=32e9bb46
+HOME_URL="https://github.com/bottlerocket-os/bottlerocket"
+SUPPORT_URL="https://github.com/bottlerocket-os/bottlerocket/discussions"
+BUG_REPORT_URL="https://github.com/bottlerocket-os/bottlerocket/issues"
   {{< /tab >}}
 {{< /tabpane >}}
 


### PR DESCRIPTION
**Issue number:**

Closes #72

**Description of changes:**

Adds `/etc/os-release` content for the ECS variant/tab on the "Host Containers" page in the quickstarts section

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
