### PR TITLE
Remove reference to on-prem admin containers

### DIFF
--- a/content/en/os/1.13.x/concepts/shell-less-host/index.markdown
+++ b/content/en/os/1.13.x/concepts/shell-less-host/index.markdown
@@ -24,7 +24,7 @@ The control container is also the path to enable or enter the admin container.
 
 The admin container is designed to provide out-of-band access with elevated privileges.
 On `aws-k8s-*` and `aws-ecs-*` variants, the admin container is not enabled by default but can be turned on or entered through the control container.
-For on-prem variants (`metal-*` or `vmware-*`), the admin container is enabled by default but best security practice is to disable it and only enable it as-needed.
+The best security practice is to disable the admin container and only enable it as-needed.
 
 The admin container has read-only mount to the host file system, unrestricted an SELinux label as well as all of the capabilities of the control container.
 Using the admin container should be rare: only used as-needed and by those required.


### PR DESCRIPTION
**Issue number:**

Closes #84

**Description of changes:**
- Removes incorrect reference to on-prem variants having an default enabled admin container.


**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
