### PR TITLE
fixes non-language scoped pages to english

### DIFF
--- a/third-party/google/docsy/layouts/_default/baseof.html
+++ b/third-party/google/docsy/layouts/_default/baseof.html
@@ -1,6 +1,6 @@
 <!doctype html>
 {{ if eq .Site.Language.Lang .Site.Params.languageOverride }}
-  <html itemscope itemtype="http://schema.org/WebPage" class="no-js">
+  <html itemscope itemtype="http://schema.org/WebPage" class="no-js" lang="en">
 {{ else }}
   <html itemscope itemtype="http://schema.org/WebPage" lang="{{ .Site.Language.Lang }}" class="no-js">
 {{ end }}


### PR DESCRIPTION
**Issue number:**

Closes #109 

**Description of changes:**

The desired site structure is different from what Docsy and Hugo expect. The bottlerocket site will have a set of landing and common pages that won't be ever localized (homepage, legal disclosures, CoC, etc.) 

Previously there was an override in `baseof` that dynamically added the language when it wasn't part of the override language setting. This left some pages without a language code, causing potential accessibility issues. Since these page will be in the lingua franca of English, it's not a problem to hardcode "en" as the language for the overridden pages.


**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
