### PR TITLE
FAQ: add language used for settings

### DIFF
--- a/content/en/faqitems/settings-1-what-language-is-used.markdown
+++ b/content/en/faqitems/settings-1-what-language-is-used.markdown
@@ -1,0 +1,7 @@
++++
+question = "What language does Bottlerocket use for settings?"
+group = "Settings"
++++
+
+When defining settings in [user data](https://github.com/bottlerocket-os/bottlerocket#using-user-data), Bottlerocket uses [TOML](https://learnxinyminutes.com/docs/toml/).
+Some settings have examples available for reference, such as [the container image registry settings](https://github.com/bottlerocket-os/bottlerocket#container-image-registry-settings).


### PR DESCRIPTION
**Issue number:**

Closes #102 

**Description of changes:**

Adds a FAQ item that explains that TOML is used for defining settings, as well as linking to TOML examples.

**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
