### PR TITLE
Code blocks on small screens are not weirdly narrow

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -256,3 +256,9 @@ h1,h2,h3,h4,h5,h6 {
         background-color: transparent;
     }
 }
+
+@include media-breakpoint-down(md) {
+    .td-content .highlight {
+        max-width:unset;
+    }
+}


### PR DESCRIPTION
**Issue number:**

Closes #121

**Description of changes:**

Unsets CSS that causes code blocks to 80% of screen width below "medium" size screens (e.g. mobile)


**Terms of contribution:**

By submitting this pull request, I confirm that my contribution is made under
the terms of the licenses outlined in the LICENSE-SUMMARY file.
